### PR TITLE
Update get_prism_annaul() to address 1981 and pre 1981 issues

### DIFF
--- a/R/get_prism_annual.R
+++ b/R/get_prism_annual.R
@@ -58,7 +58,7 @@ get_prism_annual <- function(type, years = NULL ,keepZip = TRUE){
   }
   
   
-  counter <- i+1
+  counter <- length(uris_post81)+1
   
   
   ### Handle pre 1981 files

--- a/R/get_prism_annual.R
+++ b/R/get_prism_annual.R
@@ -29,7 +29,7 @@ get_prism_annual <- function(type, years = NULL ,keepZip = TRUE){
     
   
   pre_1981 <- years[years<1981]
-  post_1981 <- years[years>1981]
+  post_1981 <- years[years >= 1981]
   uris_pre81 <- vector()
   uris_post81 <- vector()
   


### PR DESCRIPTION
PR handles 2 issues:

1. fixes issue with leaving the year 1981 out of either `pre_1981` or `post_1981`
2. makes `get_prism_annual()` able to download pre 1981 data without any post 1981 data