### PR TITLE
gen_dates() improvements and fix build warnings

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,6 @@
+^.*\.Rproj$
+^\.Rproj\.user$
+^README\.Rmd$
+^figure$
+^appveyor\.yml$
+^\.travis\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 prism.Rproj
-.Rbuildignore
 .Rproj.user
 .Rdata
 .Rhistory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,11 +15,14 @@ Authors@R: c(person("Hart", "Edmund", role = c("aut","cre"),email =
 License: MIT + file LICENSE
 Imports:
     ggplot2,
+    lubridate,
     raster,
     httr,
     dplyr,
     stringr,
     magrittr,
+    purrr,
+    readr,
     utils
 LazyLoad: yes
 LazyData: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,4 +26,4 @@ VignetteBuilder: knitr
 Suggests:
     testthat,
     knitr
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Imports:
     httr,
     dplyr,
     stringr,
-    magrittr
+    magrittr,
+    utils
 LazyLoad: yes
 LazyData: yes
 VignetteBuilder: knitr

--- a/R/get_prism_dailys.R
+++ b/R/get_prism_dailys.R
@@ -21,7 +21,11 @@
 #' # Valid calls:
 #' get_prism_dailys(type="tmean", minDate = "2013-06-01", maxDate = "2013-06-14", keepZip=FALSE)
 #' get_prism_dailys(type="ppt", dates = "2013/06/01", keepZip=FALSE)
-#' get_prism_dailys(type="tmean", dates = as.Date("2013-06-01", "2013-06-14", "2014-06-30"), keepZip=FALSE)
+#' get_prism_dailys(
+#'   type="tmean", 
+#'   dates = as.Date("2013-06-01", "2013-06-14", "2014-06-30"), 
+#'   keepZip=FALSE
+#' )
 #' 
 #' # will fail:
 #' get_prism_dailys(type="ppt", minDate = "2013-06-01", dates = "2013-06-14", keepZip=FALSE)

--- a/R/get_prism_dailys.R
+++ b/R/get_prism_dailys.R
@@ -2,16 +2,32 @@
 #' @description Download daily data from the prism project at 4km grid cell resolution for precipitation, mean, min and max temperature
 #' @param type The type of data to download, must be "ppt", "tmean", "tmin", or "tmax".
 #'        Note that tmean == mean(tmin, tmax).
-#' @param minDate a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data.
+#' @param minDate a valid iso-8601 (e.g. YYYY-MM-DD) date to start downloading data. 
+#' May be provided as either a character or \code{\link[base]{Date}} class.
 #' @param maxDate  a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.
-#' @param dates a vector of iso-8601 formatted dates to download data for, can also be a single date.
+#' May be provided as either a character or \code{\link[base]{Date}} class.
+#' @param dates a vector of iso-8601 formatted dates to download data for, can 
+#' also be a single date. May be provided as either a character or 
+#' \code{\link[base]{Date}} class.
 #' @param keepZip if \code{TRUE}, leave the downloaded zip files in your 'prism.path', if \code{FALSE}, they will be deleted.
 #' @param check One of "httr" or "internal". "httr", the default, checks the file name using the web
 #' service, and downloads if that file name is not in the file system. "internal" (much faster) 
 #' only attempts to download layers that are not already in the file system as stable. "internal"
 #' should be used with caution as it is not robust to changes in version or file names.
 #' @details Dates must be in the proper format or downloading will not work properly, you can either enter a date range via minDate and maxDate, or a vector of dates, but not both. You must make sure that you have set up a valid download directory.  This must be set as options(prism.path = "YOURPATH")
+
+#' @examples 
+#' \dontrun{
+#' # Valid calls:
 #' get_prism_dailys(type="tmean", minDate = "2013-06-01", maxDate = "2013-06-14", keepZip=FALSE)
+#' get_prism_dailys(type="ppt", dates = "2013/06/01", keepZip=FALSE)
+#' get_prism_dailys(type="tmean", dates = as.Date("2013-06-01", "2013-06-14", "2014-06-30"), keepZip=FALSE)
+#' 
+#' # will fail:
+#' get_prism_dailys(type="ppt", minDate = "2013-06-01", dates = "2013-06-14", keepZip=FALSE)
+#' get_prism_dailys(type="ppt", minDate = "2013-06-01", keepZip=FALSE)
+#' }
+
 #' @importFrom httr HEAD
 #' @export
 get_prism_dailys <- function(type, minDate = NULL, maxDate =  NULL, dates = NULL, keepZip = TRUE,

--- a/R/global_variables.R
+++ b/R/global_variables.R
@@ -1,0 +1,9 @@
+# global variables added so there are no notes in R CMD check
+
+if(getRversion() >= "2.15.1"){
+  # gloabl variables from get_prism_station_md()
+  gv <- c("ELEV(m)", "elevation", "Elevation(m)", "ID", "LAT", "latitude",
+          "Latitude", "LON", "longitude", "Longitude", "name", "Name", "NAME",
+          "network", "Network", "station", "Station", "stnid")
+  utils::globalVariables(gv)
+}

--- a/R/prism_station_md.R
+++ b/R/prism_station_md.R
@@ -7,8 +7,7 @@
 #'
 #' @return A \code{tbl_df} containing metadata on the stations used for each day/variable.
 #' @export
-#'
-#' @examples
+
 get_prism_station_md <- function(type, minDate = NULL, maxDate =  NULL, dates = NULL){
   path_check()
   dates <- gen_dates(minDate = minDate, maxDate = maxDate, dates = dates)

--- a/R/prism_station_md.R
+++ b/R/prism_station_md.R
@@ -1,4 +1,6 @@
 #' Extract metadata on the stations used to generate a particular day/variable
+#' 
+#' This only extracts metadata from daily PRISM data.
 #'
 #' @param type The type of data to get metadata for, must be "ppt", "tmean", "tmin", or "tmax".
 #' @param minDate a valid iso-8601 (e.g. YYYY-MM-DD) date. The first date to extract metadata for.

--- a/R/prism_station_md.R
+++ b/R/prism_station_md.R
@@ -10,8 +10,8 @@
 #'
 #' @examples
 get_prism_station_md <- function(type, minDate = NULL, maxDate =  NULL, dates = NULL){
-  prism:::path_check()
-  dates <- prism:::gen_dates(minDate = minDate, maxDate = maxDate, dates = dates)
+  path_check()
+  dates <- gen_dates(minDate = minDate, maxDate = maxDate, dates = dates)
   folders_to_get <- subset_prism_folders(type = type, dates = dates)
   if(length(folders_to_get) == 0){
     stop("None of the requested dates are available.")

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -172,6 +172,10 @@ gen_dates <- function(minDate, maxDate, dates){
     stop("You can enter a date range or a vector of dates, but not both")
   }
   
+  if((!is.null(maxDate) & is.null(minDate)) | (!is.null(minDate) & is.null(maxDate))){
+    stop("Both minDate and maxDate must be specified if specifying a date range")
+  }
+  
   if(!is.null(dates)){
     # make sure it is cast as a date if it was provided as a character
     dates <- as.Date(dates)

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -168,7 +168,7 @@ get_metadata <- function(type, dates = NULL, minDate = NULL, maxDate = NULL){
 #' @inheritParams get_prism_dailys
 #' @return Vector of dates
 gen_dates <- function(minDate, maxDate, dates){
-  if(!is.null(dates) && !is.null(maxDate)){
+  if((!is.null(dates) && !is.null(maxDate)) | (!is.null(dates) && !is.null(minDate))){
     stop("You can enter a date range or a vector of dates, but not both")
   }
   

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -180,9 +180,9 @@ gen_dates <- function(minDate, maxDate, dates){
   if(is.null(dates)){
     minDate <- as.Date(minDate)
     maxDate <- as.Date(maxDate)
-    dates <- seq(as.Date(minDate), as.Date(maxDate), by="days")
+    dates <- seq(minDate, maxDate, by="days")
     
-    if(as.Date(minDate) > as.Date(maxDate)){
+    if(minDate > maxDate){
       stop("Your minimum date must be less than your maximum date")
     }
   }

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -140,7 +140,7 @@ get_metadata <- function(type, dates = NULL, minDate = NULL, maxDate = NULL){
     stop("No files exist to obtain metadata from.")
   }
   out <- lapply(1:length(final_txt_full), function(i){
-    readin <- tryCatch(read.delim(final_txt_full[i], sep = "\n", 
+    readin <- tryCatch(utils::read.delim(final_txt_full[i], sep = "\n", 
                                   header = FALSE, stringsAsFactors = FALSE),
                        error = function(e){
                          warning(e)

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -230,12 +230,12 @@ gen_dates <- function(minDate, maxDate, dates){
   dates
 }
 
-#' Get the resolution text string
-#' @description To account for the ever changing name structure, here we will scrape the HTTP directory listing and grab it instead of relying on hard coded strings that need changing
-#' @param type the type of data you're downloading, should be tmax, tmin etc...
-#' @param temporal The temporal resolution of the data, monthly, daily, etc...
-#' @param yr the year of data that's being requested, in numeric form
-
+# --------------- extract_version Roxygen tags
+# Get the resolution text string
+# @description To account for the ever changing name structure, here we will scrape the HTTP directory listing and grab it instead of relying on hard coded strings that need changing
+# @param type the type of data you're downloading, should be tmax, tmin etc...
+# @param temporal The temporal resolution of the data, monthly, daily, etc...
+# @param yr the year of data that's being requested, in numeric form
 #extract_version <- function(type, temporal, yr){
 #  base <- paste0("ftp://prism.nacse.org/", temporal, "/", type, "/", yr, "/")
 ##  dirlist <- RCurl::getURL(base, ftp.use.epsv = FALSE, dirlistonly = TRUE)
@@ -248,7 +248,15 @@ gen_dates <- function(minDate, maxDate, dates){
 #  return(sp2[1])
 #}
 
-# Subsets prism folders on the disk by type and date.
+#' Subsets prism folders on the disk by type and date
+#' 
+#' Looks through all of the PRISM data that is donwloaded in your \code{prism.path}
+#' and returns the subset based on \code{type} and \code{dates}.
+#' 
+#' @param type The type of data you want to subset. Should be tmax, tmin, tmean, 
+#' ppt, vpdmin, or vpdmax
+#' @param dates A vector of the dates you wish to subset as a string
+#' 
 subset_prism_folders <- function(type, dates){
   path_check()
   dates_str <- gsub("-", "", dates)

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -180,11 +180,12 @@ gen_dates <- function(minDate, maxDate, dates){
   if(is.null(dates)){
     minDate <- as.Date(minDate)
     maxDate <- as.Date(maxDate)
-    dates <- seq(minDate, maxDate, by="days")
     
     if(minDate > maxDate){
       stop("Your minimum date must be less than your maximum date")
     }
+    
+    dates <- seq(minDate, maxDate, by="days")
   }
   dates
 }

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -273,8 +273,7 @@ subset_prism_folders <- function(type, dates){
       stringr::str_subset("4kmD1_")
   }
   # Don't want zips
-  type_folders <- type_folders %>% 
-    .[!stringr::str_detect(., ".zip")]
+  type_folders <- type_folders[!stringr::str_detect(type_folders, ".zip")]
   
   type_folders %>% 
     stringr::str_subset(paste(dates_str, collapse = "|"))

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -164,10 +164,27 @@ get_metadata <- function(type, dates = NULL, minDate = NULL, maxDate = NULL){
   }
 }
 
+is_within_daily_range <- function(dates)
+{
+  # day the record starts
+  minDay <- as.Date("1895-01-01") # need to verify
+  # assume data has posted for yesterday
+  #** may want to enhance this computation to see if it works for people using
+  # this in other time zones. Probably not critical since it will eventually 
+  # throw an error on downloading, but this will help catch it earlier
+  maxDay <- Sys.Date() - 1 # also need to verify this is accurate 
+  
+  # all dates need to be within range
+  all(dates <= maxDay & dates >= minDay)
+}
+
 #' @title Processes dates as this appears many times.
 #' @inheritParams get_prism_dailys
 #' @return Vector of dates
 gen_dates <- function(minDate, maxDate, dates){
+  if(all(is.null(dates), is.null(minDate), is.null(maxDate)))
+    stop("You must specify either a date range (minDate and maxDate) or a vector of dates")
+  
   if((!is.null(dates) && !is.null(maxDate)) | (!is.null(dates) && !is.null(minDate))){
     stop("You can enter a date range or a vector of dates, but not both")
   }
@@ -179,6 +196,9 @@ gen_dates <- function(minDate, maxDate, dates){
   if(!is.null(dates)){
     # make sure it is cast as a date if it was provided as a character
     dates <- as.Date(dates)
+    
+    if(!is_within_daily_range(dates))
+      stop("Please ensure all dates fall within the valid Prism data record")
   }
   
   if(is.null(dates)){
@@ -188,6 +208,9 @@ gen_dates <- function(minDate, maxDate, dates){
     if(minDate > maxDate){
       stop("Your minimum date must be less than your maximum date")
     }
+    
+    if(!is_within_daily_range(c(minDate, maxDate)))
+      stop("Please ensure minDate and maxData are within the available Prism data record")
     
     dates <- seq(minDate, maxDate, by="days")
   }

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -172,6 +172,11 @@ gen_dates <- function(minDate, maxDate, dates){
     stop("You can enter a date range or a vector of dates, but not both")
   }
   
+  if(!is.null(dates)){
+    # make sure it is cast as a date if it was provided as a character
+    dates <- as.Date(dates)
+  }
+  
   if(is.null(dates)){
     minDate <- as.Date(minDate)
     maxDate <- as.Date(maxDate)

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -164,6 +164,17 @@ get_metadata <- function(type, dates = NULL, minDate = NULL, maxDate = NULL){
   }
 }
 
+#' Checks to see if the dates (days) specified are within the available Prism record
+#' 
+#' Prism daily record begins January 1, 1895, and assumes that it ends yesterday, 
+#' i.e., \code{Sys.Date() - 1}.
+#' 
+#' @param dates a vector of dates (class Date)
+#' @return \code{TRUE} if all values in \code{dates} are within the available Prism
+#' record. Otherwise, returns \code{FALSE}
+#' @keywords internal
+#' @noRd
+
 is_within_daily_range <- function(dates)
 {
   # day the record starts

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -189,7 +189,9 @@ is_within_daily_range <- function(dates)
   all(dates <= maxDay & dates >= minDay)
 }
 
-#' @title Processes dates as this appears many times.
+#' @title Processes dates as this appears many times
+#' @description Given either a vector of \code{dates} or a \code{minDate} and 
+#' \code{maxDate}, return a vector of class Date. 
 #' @inheritParams get_prism_dailys
 #' @return Vector of dates
 gen_dates <- function(minDate, maxDate, dates){

--- a/man/check_corrupt.Rd
+++ b/man/check_corrupt.Rd
@@ -10,11 +10,15 @@ check_corrupt(type, minDate = NULL, maxDate = NULL, dates = NULL)
 \item{type}{The type of data to download, must be "ppt", "tmean", "tmin", or "tmax".
 Note that tmean == mean(tmin, tmax).}
 
-\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data.}
+\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data. 
+May be provided as either a character or \code{\link[base]{Date}} class.}
 
-\item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.}
+\item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.
+May be provided as either a character or \code{\link[base]{Date}} class.}
 
-\item{dates}{a vector of iso-8601 formatted dates to download data for, can also be a single date.}
+\item{dates}{a vector of iso-8601 formatted dates to download data for, can 
+also be a single date. May be provided as either a character or 
+\code{\link[base]{Date}} class.}
 }
 \value{
 \code{logical} indicating whether the process 
@@ -25,4 +29,3 @@ Uses the \code{raster::stack} function
 to determine if the bil files are readable. Any that
 are not readable are redownloaded.
 }
-

--- a/man/check_corrupt.Rd
+++ b/man/check_corrupt.Rd
@@ -10,7 +10,7 @@ check_corrupt(type, minDate = NULL, maxDate = NULL, dates = NULL)
 \item{type}{The type of data to download, must be "ppt", "tmean", "tmin", or "tmax".
 Note that tmean == mean(tmin, tmax).}
 
-\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data. 
+\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start downloading data. 
 May be provided as either a character or \code{\link[base]{Date}} class.}
 
 \item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.

--- a/man/del_early_prov.Rd
+++ b/man/del_early_prov.Rd
@@ -10,14 +10,17 @@ del_early_prov(type, minDate = NULL, maxDate = NULL, dates = NULL)
 \item{type}{The type of data to download, must be "ppt", "tmean", "tmin", or "tmax".
 Note that tmean == mean(tmin, tmax).}
 
-\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data.}
+\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data. 
+May be provided as either a character or \code{\link[base]{Date}} class.}
 
-\item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.}
+\item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.
+May be provided as either a character or \code{\link[base]{Date}} class.}
 
-\item{dates}{a vector of iso-8601 formatted dates to download data for, can also be a single date.}
+\item{dates}{a vector of iso-8601 formatted dates to download data for, can 
+also be a single date. May be provided as either a character or 
+\code{\link[base]{Date}} class.}
 }
 \description{
 Searches the download folder for duplicated PRISM data
 and keeps only the newest version.
 }
-

--- a/man/del_early_prov.Rd
+++ b/man/del_early_prov.Rd
@@ -10,7 +10,7 @@ del_early_prov(type, minDate = NULL, maxDate = NULL, dates = NULL)
 \item{type}{The type of data to download, must be "ppt", "tmean", "tmin", or "tmax".
 Note that tmean == mean(tmin, tmax).}
 
-\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data. 
+\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start downloading data. 
 May be provided as either a character or \code{\link[base]{Date}} class.}
 
 \item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.

--- a/man/gen_dates.Rd
+++ b/man/gen_dates.Rd
@@ -7,13 +7,16 @@
 gen_dates(minDate, maxDate, dates)
 }
 \arguments{
-\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data.}
+\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data. 
+May be provided as either a character or \code{\link[base]{Date}} class.}
 
-\item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.}
+\item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.
+May be provided as either a character or \code{\link[base]{Date}} class.}
 
-\item{dates}{a vector of iso-8601 formatted dates to download data for, can also be a single date.}
+\item{dates}{a vector of iso-8601 formatted dates to download data for, can 
+also be a single date. May be provided as either a character or 
+\code{\link[base]{Date}} class.}
 }
 \value{
 Vector of dates
 }
-

--- a/man/gen_dates.Rd
+++ b/man/gen_dates.Rd
@@ -7,7 +7,7 @@
 gen_dates(minDate, maxDate, dates)
 }
 \arguments{
-\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data. 
+\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start downloading data. 
 May be provided as either a character or \code{\link[base]{Date}} class.}
 
 \item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.

--- a/man/gen_dates.Rd
+++ b/man/gen_dates.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utility_functions.R
 \name{gen_dates}
 \alias{gen_dates}
-\title{Processes dates as this appears many times.}
+\title{Processes dates as this appears many times}
 \usage{
 gen_dates(minDate, maxDate, dates)
 }
@@ -19,4 +19,8 @@ also be a single date. May be provided as either a character or
 }
 \value{
 Vector of dates
+}
+\description{
+Given either a vector of \code{dates} or a \code{minDate} and 
+\code{maxDate}, return a vector of class Date.
 }

--- a/man/get_metadata.Rd
+++ b/man/get_metadata.Rd
@@ -14,7 +14,7 @@ Note that tmean == mean(tmin, tmax).}
 also be a single date. May be provided as either a character or 
 \code{\link[base]{Date}} class.}
 
-\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data. 
+\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start downloading data. 
 May be provided as either a character or \code{\link[base]{Date}} class.}
 
 \item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.

--- a/man/get_metadata.Rd
+++ b/man/get_metadata.Rd
@@ -10,11 +10,15 @@ get_metadata(type, dates = NULL, minDate = NULL, maxDate = NULL)
 \item{type}{The type of data to download, must be "ppt", "tmean", "tmin", or "tmax".
 Note that tmean == mean(tmin, tmax).}
 
-\item{dates}{a vector of iso-8601 formatted dates to download data for, can also be a single date.}
+\item{dates}{a vector of iso-8601 formatted dates to download data for, can 
+also be a single date. May be provided as either a character or 
+\code{\link[base]{Date}} class.}
 
-\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data.}
+\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data. 
+May be provided as either a character or \code{\link[base]{Date}} class.}
 
-\item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.}
+\item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.
+May be provided as either a character or \code{\link[base]{Date}} class.}
 }
 \value{
 list of data.frames containing metadata. If only
@@ -24,4 +28,3 @@ one date is requested, the function returns the data.frame.
 Retrieves PRISM metadata for a given type and
 date range. The information is retrieved from the .info.txt file.
 }
-

--- a/man/get_prism_annual.Rd
+++ b/man/get_prism_annual.Rd
@@ -26,4 +26,3 @@ Data is available from 1891 until 2014, however you have to download all data fo
 get_prism_annual(type="tmean", year = 1990:2000, keepZip=FALSE)
 }
 }
-

--- a/man/get_prism_dailys.Rd
+++ b/man/get_prism_dailys.Rd
@@ -39,7 +39,11 @@ Dates must be in the proper format or downloading will not work properly, you ca
 # Valid calls:
 get_prism_dailys(type="tmean", minDate = "2013-06-01", maxDate = "2013-06-14", keepZip=FALSE)
 get_prism_dailys(type="ppt", dates = "2013/06/01", keepZip=FALSE)
-get_prism_dailys(type="tmean", dates = as.Date("2013-06-01", "2013-06-14", "2014-06-30"), keepZip=FALSE)
+get_prism_dailys(
+  type="tmean", 
+  dates = as.Date("2013-06-01", "2013-06-14", "2014-06-30"), 
+  keepZip=FALSE
+)
 
 # will fail:
 get_prism_dailys(type="ppt", minDate = "2013-06-01", dates = "2013-06-14", keepZip=FALSE)

--- a/man/get_prism_dailys.Rd
+++ b/man/get_prism_dailys.Rd
@@ -11,11 +11,15 @@ get_prism_dailys(type, minDate = NULL, maxDate = NULL, dates = NULL,
 \item{type}{The type of data to download, must be "ppt", "tmean", "tmin", or "tmax".
 Note that tmean == mean(tmin, tmax).}
 
-\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start to download data.}
+\item{minDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to start downloading data. 
+May be provided as either a character or \code{\link[base]{Date}} class.}
 
-\item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.}
+\item{maxDate}{a valid iso-8601 (e.g. YYYY-MM-DD) date to end downloading data.
+May be provided as either a character or \code{\link[base]{Date}} class.}
 
-\item{dates}{a vector of iso-8601 formatted dates to download data for, can also be a single date.}
+\item{dates}{a vector of iso-8601 formatted dates to download data for, can 
+also be a single date. May be provided as either a character or 
+\code{\link[base]{Date}} class.}
 
 \item{keepZip}{if \code{TRUE}, leave the downloaded zip files in your 'prism.path', if \code{FALSE}, they will be deleted.}
 
@@ -29,6 +33,16 @@ Download daily data from the prism project at 4km grid cell resolution for preci
 }
 \details{
 Dates must be in the proper format or downloading will not work properly, you can either enter a date range via minDate and maxDate, or a vector of dates, but not both. You must make sure that you have set up a valid download directory.  This must be set as options(prism.path = "YOURPATH")
-get_prism_dailys(type="tmean", minDate = "2013-06-01", maxDate = "2013-06-14", keepZip=FALSE)
 }
+\examples{
+\dontrun{
+# Valid calls:
+get_prism_dailys(type="tmean", minDate = "2013-06-01", maxDate = "2013-06-14", keepZip=FALSE)
+get_prism_dailys(type="ppt", dates = "2013/06/01", keepZip=FALSE)
+get_prism_dailys(type="tmean", dates = as.Date("2013-06-01", "2013-06-14", "2014-06-30"), keepZip=FALSE)
 
+# will fail:
+get_prism_dailys(type="ppt", minDate = "2013-06-01", dates = "2013-06-14", keepZip=FALSE)
+get_prism_dailys(type="ppt", minDate = "2013-06-01", keepZip=FALSE)
+}
+}

--- a/man/get_prism_monthlys.Rd
+++ b/man/get_prism_monthlys.Rd
@@ -40,4 +40,3 @@ This must be set as options(prism.path = "YOURPATH")
 get_prism_monthlys(type="tmean", years = 1990:2000, mon = 1, keepZip=FALSE)
 }
 }
-

--- a/man/get_prism_normals.Rd
+++ b/man/get_prism_normals.Rd
@@ -32,4 +32,3 @@ get_prism_normals(type="ppt",resolution = "4km",mon = 1, keepZip=FALSE)
 
 }
 }
-

--- a/man/get_prism_station_md.Rd
+++ b/man/get_prism_station_md.Rd
@@ -21,4 +21,3 @@ A \code{tbl_df} containing metadata on the stations used for each day/variable.
 \description{
 Extract metadata on the stations used to generate a particular day/variable
 }
-

--- a/man/get_prism_station_md.Rd
+++ b/man/get_prism_station_md.Rd
@@ -19,5 +19,5 @@ get_prism_station_md(type, minDate = NULL, maxDate = NULL, dates = NULL)
 A \code{tbl_df} containing metadata on the stations used for each day/variable.
 }
 \description{
-Extract metadata on the stations used to generate a particular day/variable
+This only extracts metadata from daily PRISM data.
 }

--- a/man/ls_prism_data.Rd
+++ b/man/ls_prism_data.Rd
@@ -30,4 +30,3 @@ ls_prism_data(absPath = TRUE)
 ls_prism_data(name=TRUE)
 }
 }
-

--- a/man/mon_to_string.Rd
+++ b/man/mon_to_string.Rd
@@ -21,4 +21,3 @@ Handle numeric month to string conversions
   mon_to_string(month = 12)
 }
 }
-

--- a/man/path_check.Rd
+++ b/man/path_check.Rd
@@ -9,4 +9,3 @@ path_check()
 \description{
 create new directory for user if they don't have one to store prism files
 }
-

--- a/man/pr_parse.Rd
+++ b/man/pr_parse.Rd
@@ -17,4 +17,3 @@ a properly parsed string of human readable names
 \description{
 parse the directory name into relevant metadata
 }
-

--- a/man/prism_check.Rd
+++ b/man/prism_check.Rd
@@ -20,4 +20,3 @@ or a logical vector indication those not yet downloaded..
 \description{
 check if files exist
 }
-

--- a/man/prism_image.Rd
+++ b/man/prism_image.Rd
@@ -23,4 +23,3 @@ get_prism_dailys(type="tmean", minDate = "2013-06-01", maxDate = "2013-06-14", k
 prism_image(ls_prism_data()[1])
 }
 }
-

--- a/man/prism_md.Rd
+++ b/man/prism_md.Rd
@@ -17,4 +17,3 @@ a character vector of metadata.
 \description{
 used to extract some prism metadata used in other fxns
 }
-

--- a/man/prism_slice.Rd
+++ b/man/prism_slice.Rd
@@ -28,4 +28,3 @@ p <- prism_slice(c(-73.2119,44.4758),ls_prism_data())
 print(p)
 }
 }
-

--- a/man/prism_stack.Rd
+++ b/man/prism_stack.Rd
@@ -18,4 +18,3 @@ get_prism_dailys(type="tmean", minDate = "2013-06-01", maxDate = "2013-06-14", k
 mystack <- prism_stack(ls_prism_data()[1:14])
 }
 }
-

--- a/man/prism_webservice.Rd
+++ b/man/prism_webservice.Rd
@@ -22,4 +22,3 @@ This is the workhorse function that will access the web service to download file
 get_prism_annual(type="tmean", year = 1990:2000, keepZip=FALSE)
 }
 }
-

--- a/man/process_zip.Rd
+++ b/man/process_zip.Rd
@@ -24,4 +24,3 @@ process_zip('PRISM_tmean_stable_4kmM2_1980_all_bil',
 c('PRISM_tmean_stable_4kmM2_198001_bil','PRISM_tmean_stable_4kmM2_198002_bil'))
 }
 }
-

--- a/man/subset_prism_folders.Rd
+++ b/man/subset_prism_folders.Rd
@@ -2,17 +2,17 @@
 % Please edit documentation in R/utility_functions.R
 \name{subset_prism_folders}
 \alias{subset_prism_folders}
-\title{Get the resolution text string}
+\title{Subsets prism folders on the disk by type and date}
 \usage{
 subset_prism_folders(type, dates)
 }
 \arguments{
-\item{type}{the type of data you're downloading, should be tmax, tmin etc...}
+\item{type}{The type of data you want to subset. Should be tmax, tmin, tmean, 
+ppt, vpdmin, or vpdmax}
 
-\item{temporal}{The temporal resolution of the data, monthly, daily, etc...}
-
-\item{yr}{the year of data that's being requested, in numeric form}
+\item{dates}{A vector of the dates you wish to subset as a string}
 }
 \description{
-To account for the ever changing name structure, here we will scrape the HTTP directory listing and grab it instead of relying on hard coded strings that need changing
+Looks through all of the PRISM data that is donwloaded in your \code{prism.path}
+and returns the subset based on \code{type} and \code{dates}.
 }

--- a/man/subset_prism_folders.Rd
+++ b/man/subset_prism_folders.Rd
@@ -16,4 +16,3 @@ subset_prism_folders(type, dates)
 \description{
 To account for the ever changing name structure, here we will scrape the HTTP directory listing and grab it instead of relying on hard coded strings that need changing
 }
-

--- a/tests/testthat/test_gen_dates.R
+++ b/tests/testthat/test_gen_dates.R
@@ -1,7 +1,32 @@
 
 context("Test gen_dates")
+d1 <- "2016-01-01"
+test_that("gen_dates returns expected data", {
+  expect_equal(
+    class(gen_dates(minDate = "2016-01-01", maxDate = "2016-01-01", dates = NULL)),
+    "Date"
+  )
+  expect_length(gen_dates(minDate = NULL, maxDate = NULL, dates = d1), 1)
+  expect_length(
+    gen_dates(minDate = NULL, maxDate = NULL, dates = c(d1,"2016-03-03", "2015-04-25")), 
+    3
+  )
+  expect_length(
+    gen_dates(minDate = "2015-01-01", maxDate = "2015-12-31", dates = NULL), 
+    365
+  )
+  expect_length(gen_dates(minDate = d1, maxDate = "2016-12-31", dates = NULL), 366)
+  expect_equal(
+    gen_dates(minDate = d1, maxDate = d1, dates = NULL),
+    gen_dates(minDate = NULL, maxDate = NULL, dates = d1)
+  )
+  expect_equal(
+    gen_dates(minDate = NULL, maxDate = NULL, dates = d1),
+    gen_dates(minDate = NULL, maxDate = NULL, dates = as.Date(d1))  
+  )
+})
 
-test_that("errors work properly", {
+test_that("gen_dates errors properly", {
   expect_error(gen_dates(minDate = "2016-01-01", maxDate = NULL, dates = "2016-01-02"),
                "You can enter a date range or a vector of dates, but not both")
   expect_error(gen_dates(minDate = NULL, maxDate = "2016-01-01", dates = "2016-01-02"),

--- a/tests/testthat/test_gen_dates.R
+++ b/tests/testthat/test_gen_dates.R
@@ -1,0 +1,31 @@
+
+context("Test gen_dates")
+
+test_that("errors work properly", {
+  expect_error(gen_dates(minDate = "2016-01-01", maxDate = NULL, dates = "2016-01-02"),
+               "You can enter a date range or a vector of dates, but not both")
+  expect_error(gen_dates(minDate = NULL, maxDate = "2016-01-01", dates = "2016-01-02"),
+               "You can enter a date range or a vector of dates, but not both")
+  expect_error(gen_dates(minDate = "2016-01-01", maxDate = NULL, dates = NULL),
+               "Both minDate and maxDate must be specified if specifying a date range")
+  expect_error(gen_dates(minDate = NULL, maxDate = "2016-01-01", dates = NULL),
+               "Both minDate and maxDate must be specified if specifying a date range")
+  expect_error(gen_dates(minDate = "01-30-2016", maxDate = "2016-01-02", dates = NULL),
+               "character string is not in a standard unambiguous format")
+  expect_error(gen_dates(minDate = "2016-01-01", maxDate = "Jan 12, 2016", dates = NULL),
+               "character string is not in a standard unambiguous format")
+  expect_error(gen_dates(minDate = NULL, maxDate = NULL, dates = "12/15/2016"),
+               "character string is not in a standard unambiguous format")
+  expect_error(gen_dates(minDate = NULL, maxDate = NULL, dates = NULL),
+               "You must specify either a date range (minDate and maxDate) or a vector of dates",
+               fixed = TRUE)
+  expect_error(gen_dates(minDate = "2016-01-10", maxDate = "2016-01-02", dates = NULL),
+               "Your minimum date must be less than your maximum date")
+  # check that dates that are specified wrong, but can convert to Date return an 
+  # error because they fall outside the range of data available
+  expect_error(gen_dates(minDate = "1/1/2016", maxDate = "2016/1/2", dates = NULL),
+               "Please ensure minDate and maxData are within the available Prism data record")
+  expect_error(gen_dates(minDate = NULL, maxDate = NULL, dates = c("1/1/2016", "1/2/2016", "2016/1/3")),
+               "Please ensure all dates fall within the valid Prism data record")
+})
+


### PR DESCRIPTION
This PR improves `gen_dates()` and makes minor changes to fix the travis build warnings and notes. 

**gen_dates() improvements**
This PR fixes #66 by converting dates argument to be of class Date.

It also includes several other minor improvements to the `gen_dates()` function, mostly in the form of additional errors if different combinations of `minDate`, `maxDate` and `dates` are passed to it.

Tests for `gen_dates()` are added, and there is a minor documentation update to `get_prism_dailys()` to clarify that `minDate`, `maxDate` and `dates` can be characters or Dates.

**fix build warnings**
- mostly trivial modifications to fix warnings during build. 
- added several packages to imports
- created global variables as a quick fix for the warnings about unknown global variables in `get_prism_station_md()`