### PR TITLE
only run windows specific test on windows

### DIFF
--- a/tests/testthat/test-prism_set_dl_dir.R
+++ b/tests/testthat/test-prism_set_dl_dir.R
@@ -16,5 +16,6 @@ test_that("prism_set_dl_dir() works", {
 
 test_that("prism_set_dl_dir() fails correctly on windows", {
   skip_on_travis()
+  skip_on_os(c("mac", "linux", "solaris"))
   expect_warning(expect_error(prism_set_dl_dir(f3)))
 })


### PR DESCRIPTION
I think the last test for `prism_set_dl_dir` should only be run on Windows as the tagline states:

> prism_set_dl_dir() fails correctly on windows

This PR skips the test if the machine is a mac, linux, or solaris machine