### PR TITLE
User can specify base URL

### DIFF
--- a/R/get_prism_annual.R
+++ b/R/get_prism_annual.R
@@ -25,6 +25,12 @@
 #'   annual data, this defaults to `FALSE`. When downloading monthly data, this
 #'   defaults to `TRUE`.
 #'   
+#' @param service Either \code{NULL} (default) or a URL provided by PRISM staff
+#'   for subscription-based service. Example:
+#'   "http://services.nacse.org/prism/data/subscription/800m". To use the
+#'	subscription option, you must using a IP addresses registered with PRISM
+#'  staff.
+#'
 #' @details 
 #' A valid download directory must exist before downloading any prism data. This
 #' can be set using [prism_set_dl_dir()] and can be verified using 
@@ -47,7 +53,7 @@
 #' 
 #' @export
 get_prism_annual <- function(type, years = NULL, keepZip = TRUE, 
-                             keep_pre81_months = FALSE)
+                             keep_pre81_months = FALSE, service = NULL)
 {
   ### parameter and error handling
   
@@ -68,12 +74,16 @@ get_prism_annual <- function(type, years = NULL, keepZip = TRUE,
   uris_pre81 <- vector()
   uris_post81 <- vector()
   
+  if (is.null(service)) {
+	service <- "http://services.nacse.org/prism/data/public/4km"
+  }  
+  
   if (length(pre_1981)) {
     uris_pre81 <- sapply(
       pre_1981,
       function(x) {
         paste(
-          "http://services.nacse.org/prism/data/public/4km", type, x, sep = "/"
+          service, type, x, sep = "/"
         )
       }
     )

--- a/R/get_prism_dailys.R
+++ b/R/get_prism_dailys.R
@@ -13,6 +13,12 @@
 #'
 #' @param check One of "httr" or "internal". See details.
 #'  
+#' @param service Either \code{NULL} (default) or a URL provided by PRISM staff
+#'   for subscription-based service. Example:
+#'   "http://services.nacse.org/prism/data/subscription/800m". To use the
+#'	subscription option, you must using a IP addresses registered with PRISM
+#'  staff.
+#'
 #' @details 
 #' For the `check` parameter, "httr", the default, checks the file name using 
 #' the web service, and downloads if that file name is not in the file system. 
@@ -66,7 +72,8 @@
 #'
 #' @export
 get_prism_dailys <- function(type, minDate = NULL, maxDate =  NULL, 
-                             dates = NULL, keepZip = TRUE, check = "httr")
+                             dates = NULL, keepZip = TRUE, check = "httr",
+							 service = NULL)
 {
   prism_check_dl_dir()
   check <- match.arg(check, c("httr", "internal"))
@@ -81,10 +88,14 @@ get_prism_dailys <- function(type, minDate = NULL, maxDate =  NULL,
   
   type <- match.arg(type, prism_vars())
   
+   if (is.null(service)) {
+	service <- "http://services.nacse.org/prism/data/public/4km"
+  }
+
   uri_dates <- gsub(pattern = "-",replacement = "",dates)
   uris <- sapply(uri_dates, function(x) {
     paste(
-      "http://services.nacse.org/prism/data/public/4km", type, x, 
+      service, type, x, 
       sep = "/"
     )
   })

--- a/R/get_prism_monthlys.R
+++ b/R/get_prism_monthlys.R
@@ -13,7 +13,7 @@
 #' 
 #' @export
 get_prism_monthlys <- function(type, years = NULL, mon = NULL, keepZip = TRUE,
-                               keep_pre81_months = TRUE)
+                               keep_pre81_months = TRUE, service = NULL)
 {
   ### parameter and error handling
 
@@ -43,12 +43,16 @@ get_prism_monthlys <- function(type, years = NULL, mon = NULL, keepZip = TRUE,
   uris_pre81 <- vector()
   uris_post81 <- vector()
   
+  if (is.null(service)) {
+	service <- "http://services.nacse.org/prism/data/public/4km"
+  }
+  
   if (length(pre_1981)) {
     uris_pre81 <- sapply(
       pre_1981,
       function(x) {
         paste(
-          "http://services.nacse.org/prism/data/public/4km", type, x, sep = "/"
+          service, type, x, sep = "/"
         )
       }
     )


### PR DESCRIPTION
Added argument to get_prism_dailys, get_prism_monthlys, and get_prism_annual to allow users to specify the service (ULR) from which the download is obtained. This allows users to specify the URL for the subscription version of PRISM (800-m daily, monthly, and annual). If not specified, the URL for the 4-km resolution, free version is used.