### PR TITLE
Addition of an `unzip` argument to optionally not unzip downloads

### DIFF
--- a/R/get_prism_annual.R
+++ b/R/get_prism_annual.R
@@ -13,9 +13,12 @@
 #'   mean(tmin, tmax)`.
 #'   
 #' @param years a valid numeric year, or vector of years, to download data for. 
-#'   
-#' @param keepZip if `TRUE`, leave the downloaded zip files in your 
-#'   'prism.path', if `FALSE`, they will be deleted.
+#'
+#' @param unzip if `TRUE`, unzip the downloaded zip files in your 'prism.path'.
+#' 
+#' @param keepZip if `TRUE`, leave the downloaded zip files in your
+#'   'prism.path', if `FALSE`, they will be deleted. If `unzip` is `FALSE`, this
+#'   argument has no effect.
 #'   
 #' @param keep_pre81_months The pre-1981 data includes all monthly data and the 
 #'   annual data for the specified year. If you need annual and monthly data it
@@ -55,7 +58,7 @@
 #' @rdname get_prism_data
 #' 
 #' @export
-get_prism_annual <- function(type, years, keepZip = TRUE, 
+get_prism_annual <- function(type, years, unzip = TRUE, keepZip = TRUE, 
                              keep_pre81_months = FALSE, service = NULL)
 {
   ### parameter and error handling
@@ -101,7 +104,7 @@ get_prism_annual <- function(type, years, keepZip = TRUE,
   if(length(uris_post81) > 0){    
     
     for(i in seq_along(uris_post81)) {
-      prism_webservice(uris_post81[i],keepZip)
+      prism_webservice(uris_post81[i],unzip,keepZip)
       setTxtProgressBar(download_pb, i)
     }
   }
@@ -115,6 +118,7 @@ get_prism_annual <- function(type, years, keepZip = TRUE,
     for(j in seq_along(uris_pre81)){
       tmp <- prism_webservice(
         uris_pre81[j], 
+        unzip,
         keepZip, 
         returnName = TRUE, 
         pre81_months = ""

--- a/R/get_prism_dailys.R
+++ b/R/get_prism_dailys.R
@@ -66,8 +66,8 @@
 #'
 #' @export
 get_prism_dailys <- function(type, minDate = NULL, maxDate =  NULL, 
-                             dates = NULL, keepZip = TRUE, check = "httr",
-                             service = NULL)
+                             dates = NULL, unzip = TRUE, keepZip = TRUE, 
+                             check = "httr", service = NULL)
 {
   prism_check_dl_dir()
   
@@ -115,7 +115,7 @@ get_prism_dailys <- function(type, minDate = NULL, maxDate =  NULL,
   
   if(length(uris) > 0){
     for(i in seq_along(uris)){
-      prism_webservice(uri = uris[i],keepZip)
+      prism_webservice(uri = uris[i],unzip,keepZip)
       setTxtProgressBar(download_pb, i)
     }
   } else {

--- a/R/get_prism_monthlys.R
+++ b/R/get_prism_monthlys.R
@@ -13,7 +13,7 @@
 #' @rdname get_prism_data
 #' 
 #' @export
-get_prism_monthlys <- function(type, years, mon = 1:12, keepZip = TRUE,
+get_prism_monthlys <- function(type, years, mon = 1:12, unzip = TRUE, keepZip = TRUE,
                                keep_pre81_months = TRUE, service = NULL)
 {
   ### parameter and error handling
@@ -73,7 +73,7 @@ get_prism_monthlys <- function(type, years, mon = 1:12, keepZip = TRUE,
   ### Handle post 1981 data
   if(length(uris_post81) > 0){    
       for(i in seq_along(uris_post81)){
-        prism_webservice(uris_post81[i],keepZip)
+        prism_webservice(uris_post81[i],unzip,keepZip)
         setTxtProgressBar(download_pb, i)
     }
   }
@@ -87,6 +87,7 @@ get_prism_monthlys <- function(type, years, mon = 1:12, keepZip = TRUE,
     for (j in seq_along(uris_pre81)) {
       tmp <- prism_webservice(
         uris_pre81[j], 
+        unzip,
         keepZip, 
         returnName = TRUE,
         pre81_months = mon

--- a/R/get_prism_normals.R
+++ b/R/get_prism_normals.R
@@ -35,7 +35,7 @@
 #' 
 #' @export
 get_prism_normals <- function(type, resolution, mon = NULL, annual = FALSE,  
-                              keepZip = TRUE)
+                              unzip = TRUE, keepZip = TRUE)
 {
   ### parameter and error handling
   prism_check_dl_dir()
@@ -67,7 +67,7 @@ get_prism_normals <- function(type, resolution, mon = NULL, annual = FALSE,
   mpb <- txtProgressBar(min = 0, max =length(uris), style = 3)
  
   for(i in seq_along(uris)){
-    prism_webservice(uris[i],keepZip)
+    prism_webservice(uris[i],unzip,keepZip)
     setTxtProgressBar(mpb, i)
     
   }

--- a/R/prism_webservice.R
+++ b/R/prism_webservice.R
@@ -5,7 +5,10 @@
 #' 
 #' @param uri a valid PRISM web service URI
 #' 
-#' @param keepZip TRUE or FALSE, keep zip files once they have been unzipped
+#' @param unzip TRUE or FALSE, unzip the zip files after downloading them
+#' 
+#' @param keepZip TRUE or FALSE, keep zip files once they have been unzipped. If
+#'   `unzip` is FALSE, then this has no effect.
 #' 
 #' @param returnName TRUE or FALSE, if TRUE the name of the file that was 
 #'   downloaded is returned
@@ -25,7 +28,7 @@
 #' }
 #' @noRd
 
-prism_webservice <- function(uri, keepZip = FALSE, returnName = FALSE, 
+prism_webservice <- function(uri, unzip = TRUE, keepZip = FALSE, returnName = FALSE, 
                              pre81_months = NULL)
 {
   ## Get file name
@@ -46,7 +49,7 @@ prism_webservice <- function(uri, keepZip = FALSE, returnName = FALSE,
     message("\n", fn, " already exists. Skipping downloading.")
     return(NULL)
   } else {
-  
+    
     outFile <- paste(options("prism.path"), fn, sep="/")
     
     tryNumber <- 1
@@ -69,7 +72,7 @@ prism_webservice <- function(uri, keepZip = FALSE, returnName = FALSE,
       
       tryNumber <- tryNumber + 1
     }
-  
+    
     if (!downloaded) {
       warning(paste0("Downloading failed"))
     } else {
@@ -87,16 +90,19 @@ prism_webservice <- function(uri, keepZip = FALSE, returnName = FALSE,
         return(NULL)
       }
       
-      ofolder <- strsplit(outFile, ".zip")[[1]]
-      suppressWarnings(
-        utils::unzip(outFile, exdir = ofolder)
-      )
-      
-      # make sure unzipped folder is not empty
-      check_unzipped_folder(ofolder, uri)
-      
-      if (!keepZip) {
-        file.remove(outFile)
+      if (isTRUE(unzip)) {
+        
+        ofolder <- strsplit(outFile, ".zip")[[1]]
+        suppressWarnings(
+          utils::unzip(outFile, exdir = ofolder)
+        )
+        
+        # make sure unzipped folder is not empty
+        check_unzipped_folder(ofolder, uri)
+        
+        if (!keepZip) {
+          file.remove(outFile)
+        }
       }
     }
   }

--- a/man/get_prism_data.Rd
+++ b/man/get_prism_data.Rd
@@ -11,6 +11,7 @@
 get_prism_annual(
   type,
   years,
+  unzip = TRUE,
   keepZip = TRUE,
   keep_pre81_months = FALSE,
   service = NULL
@@ -21,6 +22,7 @@ get_prism_dailys(
   minDate = NULL,
   maxDate = NULL,
   dates = NULL,
+  unzip = TRUE,
   keepZip = TRUE,
   check = "httr",
   service = NULL
@@ -30,12 +32,20 @@ get_prism_monthlys(
   type,
   years,
   mon = 1:12,
+  unzip = TRUE,
   keepZip = TRUE,
   keep_pre81_months = TRUE,
   service = NULL
 )
 
-get_prism_normals(type, resolution, mon = NULL, annual = FALSE, keepZip = TRUE)
+get_prism_normals(
+  type,
+  resolution,
+  mon = NULL,
+  annual = FALSE,
+  unzip = TRUE,
+  keepZip = TRUE
+)
 }
 \arguments{
 \item{type}{The type of data to download. Must be "ppt", "tmean", "tmin",
@@ -43,8 +53,11 @@ get_prism_normals(type, resolution, mon = NULL, annual = FALSE, keepZip = TRUE)
 
 \item{years}{a valid numeric year, or vector of years, to download data for.}
 
+\item{unzip}{if \code{TRUE}, unzip the downloaded zip files in your 'prism.path'.}
+
 \item{keepZip}{if \code{TRUE}, leave the downloaded zip files in your
-'prism.path', if \code{FALSE}, they will be deleted.}
+'prism.path', if \code{FALSE}, they will be deleted. If \code{unzip} is \code{FALSE}, this
+argument has no effect.}
 
 \item{keep_pre81_months}{The pre-1981 data includes all monthly data and the
 annual data for the specified year. If you need annual and monthly data it


### PR DESCRIPTION
This is a draft addressing #124.  Things I'm still uncertain about, but would be happy to add to this PR:

- How this should/shouldn't interact with `process_zip()` that deals with pre-1980 files
- Where to put a test for this (seems like tests in test-prism_webservice.R purposefully don't hit the API)
- Would it be helpful to document how to read in data from a .zip without unzipping? E.g. in an example or short vignette?