### PR TITLE
Update prism_archive_subset.R

### DIFF
--- a/R/prism_archive_subset.R
+++ b/R/prism_archive_subset.R
@@ -61,12 +61,12 @@
 #' # get all annual tmin
 #' prism_archive_subset("tmin", "annual")
 #' # get only 2000-2015 annual tmin
-#' prism_subset_folder("tmin", "annual", years = 2000-2015)
+#' prism_subset_folder("tmin", "annual", years = 2000:2015)
 #' 
 #' # get monthly precipitation for 2000-2010
-#' prism_archive_subset("ppt", "monthly", years = 2000-2010)
+#' prism_archive_subset("ppt", "monthly", years = 2000:2010)
 #' # get only June-August monthly precip data for 2000-2010
-#' prism_archive_subset("ppt", "monthly", years = 2000-2010, mon = 6:8)
+#' prism_archive_subset("ppt", "monthly", years = 2000:2010, mon = 6:8)
 #' 
 #' # get all daily tmax for July-August in 2010
 #' prism_archive_subset("tmax", "daily", years = 2010, mon = 7:8)


### PR DESCRIPTION
In the examples that give a range of years, a dash (-) is used instead of a colon, which is needed to run the examples. Ex: 2000-2010 instead of the needed 2000:2010