### PR TITLE
Add PRISM variables for "solclear", "solslope", "soltotal", "soltrans" normals

### DIFF
--- a/R/get_prism_normals.R
+++ b/R/get_prism_normals.R
@@ -39,7 +39,7 @@ get_prism_normals <- function(type, resolution, mon = NULL, annual = FALSE,
 {
   ### parameter and error handling
   prism_check_dl_dir()
-  type <- match.arg(type, prism_vars())
+  type <- match.arg(type, prism_vars(normals = TRUE))
   resolution <- match.arg(resolution, c("4km","800m"))
   
   if (is.null(mon) & !annual) {

--- a/R/pd_get.R
+++ b/R/pd_get.R
@@ -134,7 +134,7 @@ pr_parse <- function(p,returnDate = FALSE){
     "800m resolution"
   )
   
-  type <- prism_var_names()[type]
+  type <- prism_var_names(normals = normals)[type]
 
   md_string <- paste(ds,ures,type,sep = " - ")
   if(!returnDate){

--- a/R/prism_archive_subset.R
+++ b/R/prism_archive_subset.R
@@ -89,12 +89,15 @@ prism_archive_subset <- function(type, temp_period, years = NULL, mon = NULL,
 {
   prism_check_dl_dir()
   
-  type <- match.arg(type, prism_vars())
 
   temp_period <- match.arg(
     temp_period, 
     c("annual", "monthly", "daily", "monthly normals", "annual normals")
   )
+  
+  normals <- grepl("normals", temp_period)
+  
+  type <- match.arg(type, prism_vars(normals = normals))
   
   check_subset_folders_args(
     type, temp_period, years, mon, minDate, maxDate, dates, resolution

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -285,18 +285,27 @@ gen_dates <- function(minDate, maxDate, dates){
 
 #' Returns the available prism variables.
 #' @noRd
-prism_vars <- function()
+prism_vars <- function(normals = FALSE)
 {
-  c("ppt", "tmean", "tmin", "tmax", "vpdmin", "vpdmax", "tdmean")
+  x <- c("ppt", "tmean", "tmin", "tmax", "vpdmin", "vpdmax", "tdmean")
+  
+  if (isTRUE(normals)) {
+    x <- c(x, "solclear", "solslope", "soltotal", "soltrans")
+  }
 }
 
 # maps prism variables and names
-prism_var_names <- function() {
+prism_var_names <- function(normals = FALSE) {
   x <- c("Precipitation", "Mean temperature", "Minimum temperature", 
          "Maximum temperature", "Minimum vapor pressure deficit",
          "Maximum vapor pressure deficit", "Mean dew point temperature")
   
-  names(x) <- prism_vars()
+  if (isTRUE(normals)) {
+    x <- c(x, "Solar radiation (clear sky)", "Solar radiation (sloped)", 
+              "Solar radiation (total)", "Cloud transmittance")
+  }
+  
+  names(x) <- prism_vars(normals = normals)
 
   x
 }

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -292,6 +292,8 @@ prism_vars <- function(normals = FALSE)
   if (isTRUE(normals)) {
     x <- c(x, "solclear", "solslope", "soltotal", "soltrans")
   }
+  
+  x
 }
 
 # maps prism variables and names


### PR DESCRIPTION
This PR adds support for downloading "Solar radiation (clear sky)" (`solclear`), "Solar radiation (sloped)" (`solslope`), "Solar radiation (total)" (`soltotal`), "Cloud transmittance" (`soltrans`) variables . These variables are only available for the monthly and annual PRISM Normals e.g. https://ftp.prism.oregonstate.edu/normals/monthly/800m/solclear/